### PR TITLE
:arrow_up: django-compressor 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ndg-httpsclient==0.4.0
 contextlib2==0.5.1
 
 django-appconf==1.0.1
-django-compressor==1.6
+django-compressor==2.0
 django-paging==0.2.5
 djangowind==0.14.3
 sorl==3.1


### PR DESCRIPTION
required for Django 1.9